### PR TITLE
allow to compile morse_cli using lto

### DIFF
--- a/morsectrl.h
+++ b/morsectrl.h
@@ -77,7 +77,7 @@ struct MM_CLI_HANDLER_ALIGN command_handler
 #define __MM_CLI_HANDLER(\
     command, _is_intf_cmd, _direct_chip_supported_cmd, deprecated, custom_help) \
     int command##_init(struct morsectrl *mors, struct mm_argtable *mmargs); \
-    __attribute__((section("cli_handlers"))) MM_CLI_HANDLER_ALIGN \
+    __attribute__((used)) __attribute__((no_reorder)) __attribute__((section("cli_handlers"))) MM_CLI_HANDLER_ALIGN \
     struct command_handler command##_cli_handler = { \
         #command, \
         command##_init, \

--- a/transport/transport_private.h
+++ b/transport/transport_private.h
@@ -100,7 +100,6 @@ struct morsectrl_transport
     bool debug;
 };
 
-
 #define REGISTER_TRANSPORT(_ops) \
     const struct morsectrl_transport_ops * const \
-    __attribute__((section("transport_ops_table"))) transport_##_ops = &(_ops)
+    __attribute__((used)) __attribute__((no_reorder)) __attribute__((section("transport_ops_table"))) transport_##_ops = &(_ops)


### PR DESCRIPTION
this patch will allow to compile morse_cli using lto optimisation since sections will be stripped otherwise or/and reordered and fail to work. stripped binary sizes (using all options, including usb, ftdi, sdio)

original - 219177 bytes
lto - 189225  bytes
lto + mips16 - 149637 bytes

( mips16 + lto : -minterlink-mips16 -mips16 -flto -fwhole-program -flto-partition=none)